### PR TITLE
Fix Gemini API model error by updating to stable gemini-2.5-pro

### DIFF
--- a/internal/server/articles.go
+++ b/internal/server/articles.go
@@ -270,7 +270,7 @@ func extractArticleMetadata(articleLink string) (*types.Article, error) {
 
 	stream := client.Models.GenerateContentStream(
 		ctx,
-		"gemini-2.5-pro-exp-03-25",
+		"gemini-2.5-pro",
 		genai.Text(prompt),
 		config,
 	)


### PR DESCRIPTION
## Summary
- Fixed production 404 error caused by deprecated experimental model
- Updated from `gemini-2.5-pro-exp-03-25` to stable `gemini-2.5-pro`
- The experimental model is no longer available in the Gemini API

🤖 Generated with [Claude Code](https://claude.com/claude-code)